### PR TITLE
Print error message if there is an error in http.ListenAndServe

### DIFF
--- a/femmuseum/main.go
+++ b/femmuseum/main.go
@@ -43,7 +43,7 @@ func main() {
 	server.Handle("/", fs)
 
 	err := http.ListenAndServe(":3333", server)
-	if err == nil {
+	if err != nil {
 		print("Error opening the server")
 	}
 }


### PR DESCRIPTION
The condition here seems to be wrong. It says print error message when `err == nil`, but as far as I get it should be the opposite `err != nil`