### PR TITLE
Remove `buffered` argument from perf observe call

### DIFF
--- a/femmuseum/public/script.js
+++ b/femmuseum/public/script.js
@@ -3,7 +3,7 @@ const obs = new PerformanceObserver(list => {
     const entries = list.getEntries();
     console.log(entries);
  });
- obs.observe({entryTypes: ["largest-contentful-paint", "layout-shift", "first-input", "paint"]);
+ obs.observe({entryTypes: ["largest-contentful-paint", "layout-shift", "first-input", "paint"]});
  
 
 

--- a/femmuseum/public/script.js
+++ b/femmuseum/public/script.js
@@ -3,8 +3,7 @@ const obs = new PerformanceObserver(list => {
     const entries = list.getEntries();
     console.log(entries);
  });
- obs.observe({entryTypes: ["largest-contentful-paint", "layout-shift", "first-input", "paint"], 
-                    buffered: true});
+ obs.observe({entryTypes: ["largest-contentful-paint", "layout-shift", "first-input", "paint"]);
  
 
 


### PR DESCRIPTION
Adresses #4, as providing both `buffered` and `entryTypes` causes a runtime error in Firefox, source — [MDN spec](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver/observe).

TODO: perhaps we'd also need to re-zip `femmpublic.zip` for a proper fix.